### PR TITLE
added rounding when setting resolver positioning.

### DIFF
--- a/packages/main/src/IntentResolver.ts
+++ b/packages/main/src/IntentResolver.ts
@@ -80,8 +80,8 @@ export class IntentResolver {
           const wsSize = workspace.window?.getSize();
           this.window.setSize(resolverWidth, resolverHeight);
           this.window.setPosition(
-            wsPosition[0] + wsSize[0] / 2 - resolverWidth / 2,
-            wsPosition[1] + wsSize[1] / 2 - resolverHeight / 2,
+            Math.round(wsPosition[0] + wsSize[0] / 2 - resolverWidth / 2),
+            Math.round(wsPosition[1] + wsSize[1] / 2 - resolverHeight / 2),
           );
         }
 


### PR DESCRIPTION
@robmoffat  I believe this should fix the resolver window not opening bug we saw earlier today.  Either way, its the right thing to do ;).