### PR TITLE
fix for closing a single tab only

### DIFF
--- a/packages/main/src/workspace.ts
+++ b/packages/main/src/workspace.ts
@@ -50,7 +50,6 @@ export class Workspace {
       // show: false, // Use 'ready-to-show' event to show window
       height: DEFAULT_WINDOW_HEIGHT,
       width: DEFAULT_WINDOW_WIDTH,
-      closable: false,
       webPreferences: {
         webviewTag: false, // The webview tag is not recommended. Consider alternatives like iframe or Electron's BrowserView. https://www.electronjs.org/docs/latest/api/webview-tag#warning
         preload: SYSTEM_PRELOAD,

--- a/packages/main/src/workspace.ts
+++ b/packages/main/src/workspace.ts
@@ -50,6 +50,7 @@ export class Workspace {
       // show: false, // Use 'ready-to-show' event to show window
       height: DEFAULT_WINDOW_HEIGHT,
       width: DEFAULT_WINDOW_WIDTH,
+      closable: false,
       webPreferences: {
         webviewTag: false, // The webview tag is not recommended. Consider alternatives like iframe or Electron's BrowserView. https://www.electronjs.org/docs/latest/api/webview-tag#warning
         preload: SYSTEM_PRELOAD,

--- a/packages/preload/src/fdc3-1.2/index.ts
+++ b/packages/preload/src/fdc3-1.2/index.ts
@@ -1,8 +1,11 @@
 import { connect, createAPI } from './api';
+import { sail } from '../lib/sail';
 import { contextBridge } from 'electron';
 connect();
+
 //listen();
 //document.addEventListener('DOMContentLoaded', createAPI);
 const DesktopAgent = createAPI();
 /* expose the fdc3 api across the context isolation divide...*/
 contextBridge.exposeInMainWorld('fdc3', DesktopAgent);
+contextBridge.exposeInMainWorld('sail', sail);

--- a/packages/preload/src/fdc3-2.0/index.ts
+++ b/packages/preload/src/fdc3-2.0/index.ts
@@ -1,4 +1,5 @@
 import { connect, createAPI } from './api';
+import { sail } from '../lib/sail';
 import { contextBridge } from 'electron';
 connect();
 //listen();
@@ -6,3 +7,4 @@ connect();
 const DesktopAgent = createAPI();
 /* expose the fdc3 api across the context isolation divide...*/
 contextBridge.exposeInMainWorld('fdc3', DesktopAgent);
+contextBridge.exposeInMainWorld('sail', sail);

--- a/packages/preload/src/lib/sail.ts
+++ b/packages/preload/src/lib/sail.ts
@@ -1,0 +1,25 @@
+import { ipcRenderer } from 'electron';
+import { RUNTIME_TOPICS } from '/@main/handlers/runtime/topics';
+
+let id: string | undefined = undefined;
+
+/**
+ * listen for start event - assigning id for the instance
+ */
+ipcRenderer.on(RUNTIME_TOPICS.WINDOW_START, (event, args) => {
+  console.log(event.type);
+  id = args.id;
+});
+
+const close = () => {
+  ipcRenderer.send(RUNTIME_TOPICS.CLOSE_TAB, {
+    source: id,
+    data: {
+      closeType: 'view',
+    },
+  });
+};
+
+export const sail = {
+  close,
+};


### PR DESCRIPTION
There seems to be an underlying issue in Electron BrowserView implementation that is causing the parent window to close when window.close is called in the BrowserView context.  Handling the 'close' event or 'beforeunload' does not stop this.  After trying some different avenues, decided the best path was to implement a simple `sail.close()` api for the FDC3 enabled views that would handle the tab close as expected.  Added to both 1.2 and 2.0 preloads (under the separate sail namespace)

@robmoffat  can you try out with the conformance tests?